### PR TITLE
[Feat/#48] 서치 키워드 유지 및 검색 UI 개선

### DIFF
--- a/src/components/common/Header/Header.style.ts
+++ b/src/components/common/Header/Header.style.ts
@@ -12,6 +12,7 @@ export const HeaderContainer = css`
 
 export const HeaderLogo = css`
   margin: 0 1.6rem 0 2.4rem;
+  cursor: pointer;
 
   img {
     height: 3.9rem;

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 import { getCartCount } from '@apis/shoppingCart/getCartCount';
 
@@ -28,9 +28,14 @@ import SearchBar from '../SearchBar/SearchBar';
 const navItems = ['세일', '맞춤형 추천', '기프트 카드', '고객 서비스', '판매자 페이지'];
 
 const Header = () => {
-  const [cartCount, setCartCount] = useState(0); // 장바구니 초기값
-  const { updateCartCount } = useCart(); // CartContext에서 업데이트 함수
+  const [cartCount, setCartCount] = useState(0);
+  const { updateCartCount } = useCart();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // URL에서 keyword 추출
+  const searchParams = new URLSearchParams(location.search);
+  const keyword = searchParams.get('keyword') || '';
 
   // 장바구니 카운트 가져오기
   useEffect(() => {
@@ -71,7 +76,7 @@ const Header = () => {
         <IcHeaderLocation css={LocationIconStyle} />
 
         <div css={SearchBarWrapper}>
-          <SearchBar onKeywordChange={handleSearch} />
+          <SearchBar onKeywordChange={handleSearch} initialQuery={keyword} />
         </div>
 
         <div css={HeaderActionButtonsWrapper}>

--- a/src/components/common/ProductList/ProductList.tsx
+++ b/src/components/common/ProductList/ProductList.tsx
@@ -9,11 +9,11 @@ import ProductCard from '../ProductCard/ProductCard';
 
 interface ProductListProps {
   keyword: string;
-  sort: 'POPULARITY' | 'REVIEWCOUNT' | 'SALES' | 'LOWPRICE' | 'LATESTPRODUCTS'; // 정확한 타입 지정
+  sort: 'POPULARITY' | 'REVIEWCOUNT' | 'SALES' | 'LOWPRICE' | 'LATESTPRODUCTS';
 }
 
 const ProductList = ({ keyword, sort }: ProductListProps) => {
-  const [products, setProducts] = useState<ProductData[]>([]); // 명시적 타입 추가
+  const [products, setProducts] = useState<ProductData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,9 +22,9 @@ const ProductList = ({ keyword, sort }: ProductListProps) => {
       setLoading(true);
       try {
         const data = await getProducts({ keyword, sort });
-        setProducts(data); // 데이터가 올바르게 설정되도록 타입 일치
+        setProducts(data);
       } catch (err) {
-        console.error('Error fetching products:', err); // err 사용
+        console.error('Error fetching products:', err);
         setError('상품 데이터를 불러오는 중 문제가 발생했습니다.');
       } finally {
         setLoading(false);

--- a/src/components/common/SortingBar/SortingBar.tsx
+++ b/src/components/common/SortingBar/SortingBar.tsx
@@ -4,7 +4,7 @@ import { sortingBarContainer, sortingKeywordBox, activeKeywordBox } from './Sort
 
 const sortBy = [
   { key: 'POPULARITY', label: '인기순' },
-  { key: 'REVIEWCOUNT', label: '리뷰 많은 순' },
+  { key: 'REVIEWCOUNT', label: '리뷰 많은순' },
   { key: 'SALES', label: '판매순' },
   { key: 'LOWPRICE', label: '낮은 가격순' },
   { key: 'LATESTPRODUCTS', label: '신상품순' },

--- a/src/pages/search/Search.style.ts
+++ b/src/pages/search/Search.style.ts
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
 
+import theme from '@styles/theme';
+
 export const searchContainer = css`
   display: flex;
   flex-direction: column;
@@ -17,4 +19,10 @@ export const mainContainer = css`
 export const bottomLoginSection = css`
   margin-top: 8rem;
   margin-bottom: 6.4rem;
+`;
+
+export const searchResultTitle = css`
+  ${theme.font.title_b_24};
+  color: ${theme.color.black};
+  margin-bottom: 0.4rem;
 `;

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -2,7 +2,7 @@ import { Breadcrumb, FilterList, SortingBar, ProductList, BottomRecommend, Botto
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { bottomLoginSection, mainContainer, searchContainer } from './Search.style';
+import { bottomLoginSection, mainContainer, searchContainer, searchResultTitle } from './Search.style';
 
 const Search = () => {
   const location = useLocation();
@@ -26,6 +26,7 @@ const Search = () => {
           <FilterList />
         </section>
         <section>
+          <h1 css={searchResultTitle}>'{keyword}' 검색결과</h1>
           <SortingBar onSortChange={(selectedSort) => setSort(selectedSort)} />
           <ProductList keyword={keyword} sort={sort} />
           <BottomRecommend />


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) [feat/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #48 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- URL 파라미터 기반으로 서치 키워드 유지 기능 추가 (기존 로컬스토리지 방법에서 변경)
- 헤더 로고 cursor pointer 추가
- sorting bar 위에 {keyword} 검색 결과 추가

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 리뷰어를 지정했는가?
- [x] 라벨은 등록했는가?

## 📢 To Reviewers
<!-- 선택 사항 -->
- 최근 검색어를 서버에서 불러오는 거라 지금 삭제가 안 되는데 최근 검색어에 삭제 기능 보여주려면 이거에 맞춰서 다시 수정해야 할 듯,,,~

## 📸 스크린샷 or 실행영상
